### PR TITLE
Add options for the propagation to the next register and to return the pure sum

### DIFF
--- a/multipletau/core.py
+++ b/multipletau/core.py
@@ -91,8 +91,9 @@ def autocorrelate(a, m=16, deltat=1, normalize=False,
 
     Returns
     -------
-    autocorrelation: ndarray of shape (N,2)
-        the lag time (1st column) and the autocorrelation (2nd column).
+    autocorrelation: ndarray of shape (N,3)
+        the lag time (1st column), the autocorrelation (2nd column) and the
+        number of measurements in each bin (3rd column).
 
     Notes
     -----
@@ -177,7 +178,7 @@ def autocorrelate(a, m=16, deltat=1, normalize=False,
     # traces that are just larger than m):
     lenG = m + k * (m // 2) + 1
 
-    G = np.zeros((lenG, 2), dtype=dtype)
+    G = np.zeros((lenG, 3), dtype=dtype)
 
     normstat = np.zeros(lenG, dtype=dtype)
     normnump = np.zeros(lenG, dtype=dtype)
@@ -244,6 +245,7 @@ def autocorrelate(a, m=16, deltat=1, normalize=False,
                                    trace[npmd2:])
                 normstat[idx] = N - npmd2
                 normnump[idx] = N
+                G[idx, 2] = normstat[idx]
         # Check if len(trace) is even:
         if N % 2 == 1:
             N -= 1

--- a/multipletau/core.py
+++ b/multipletau/core.py
@@ -211,8 +211,13 @@ def autocorrelate(a, m=16, deltat=1, normalize=False, copy=True, dtype=None,
     # Check if len(trace) is even:
     if N % 2 == 1:
         N -= 1
-    # Add up every second element
-    trace = (trace[:N:2] + trace[1:N:2]) / 2
+    # compress every second element
+    if compress == compress_values[0]:
+        trace = (trace[:N:2] + trace[1:N:2]) / 2
+    elif compress == compress_values[1]:
+        trace = trace[:N:2]
+    elif compress == compress_values[2]:
+        trace = trace[1:N:2]
     N //= 2
     # Start iteration for each m/2 values
     for step in range(1, k + 1):
@@ -253,7 +258,7 @@ def autocorrelate(a, m=16, deltat=1, normalize=False, copy=True, dtype=None,
         # Check if len(trace) is even:
         if N % 2 == 1:
             N -= 1
-        # Add up every second element
+        # compress every second element
         if compress == compress_values[0]:
             trace = (trace[:N:2] + trace[1:N:2]) / 2
         elif compress == compress_values[1]:
@@ -450,9 +455,16 @@ def correlate(a, v, m=16, deltat=1, normalize=False, copy=True, dtype=None,
     # Check if len(trace) is even:
     if N % 2 == 1:
         N -= 1
-    # Add up every second element
-    trace1 = (trace1[:N:2] + trace1[1:N:2]) / 2
-    trace2 = (trace2[:N:2] + trace2[1:N:2]) / 2
+    # compress every second element
+    if compress == compress_values[0]:
+        trace1 = (trace1[:N:2] + trace1[1:N:2]) / 2
+        trace2 = (trace2[:N:2] + trace2[1:N:2]) / 2
+    elif compress == compress_values[1]:
+        trace1 = trace1[:N:2]
+        trace2 = trace2[:N:2]
+    elif compress == compress_values[2]:
+        trace1 = trace1[1:N:2]
+        trace2 = trace2[1:N:2]
     N //= 2
 
     for step in range(1, k + 1):
@@ -476,7 +488,7 @@ def correlate(a, v, m=16, deltat=1, normalize=False, copy=True, dtype=None,
         # Check if len(trace) is even:
         if N % 2 == 1:
             N -= 1
-        # Add up every second element
+        # compress every second element
         if compress == compress_values[0]:
             trace1 = (trace1[:N:2] + trace1[1:N:2]) / 2
             trace2 = (trace2[:N:2] + trace2[1:N:2]) / 2

--- a/multipletau/core.py
+++ b/multipletau/core.py
@@ -81,14 +81,15 @@ def autocorrelate(a, m=16, deltat=1, normalize=False, copy=True, dtype=None,
         The data type of the returned array and of the accumulator
         for the multiple-tau computation.
     compress: string
-        "average" (default): average two measurements when pushing to the next
-        level of the correlator.
-        "first": use only the first value when pushing to the next level of the
-        correlator.
-        "second": use only the second value when pushing to the next level of
-        the correlator.
-            See https://doi.org/10.1063/1.3491098 for a discussion on the
-            effect of averaging.
+        * `"average"` (default): average two measurements when pushing to the next
+          level of the correlator.
+        * `"first"`: use only the first value when pushing to the next level of the
+          correlator.
+        * `"second"`: use only the second value when pushing to the next level of
+          the correlator.
+        * See https://doi.org/10.1063/1.3491098 for a discussion on the
+          effect of averaging.
+
     return_sum: bool
         return the exact sum :math:`z_k = \\Sigma_n a_n a_{n+k}`. In addition
         :math:`M-k` is returned as a second ndarray of shape (N)
@@ -315,12 +316,14 @@ def correlate(a, v, m=16, deltat=1, normalize=False, copy=True, dtype=None,
         The data type of the returned array and of the accumulator
         for the multiple-tau computation.
     compress: string
-        "average" (default): average two measurements when pushing to the next
-        level of the correlator.
-        "first": use only the first value when pushing to the next level of the
-        correlator.
-        "second": use only the second value when pushing to the next level of
-        the correlator.
+        * `"average"` (default): average two measurements when pushing to the next
+          level of the correlator.
+        * `"first"`: use only the first value when pushing to the next level of the
+          correlator.
+        * `"second"`: use only the second value when pushing to the next level of
+          the correlator.
+        * See https://doi.org/10.1063/1.3491098 for a discussion on the
+          effect of averaging.
     return_sum: bool
         return the exact sum :math:`z_k = \\Sigma_n a_n a_{n+k}`. In addition
         :math:`M-k` is returned as a second ndarray of shape (N)

--- a/multipletau/core.py
+++ b/multipletau/core.py
@@ -245,16 +245,15 @@ def autocorrelate(a, m=16, deltat=1, normalize=False,
                                    trace[npmd2:])
                 normstat[idx] = N - npmd2
                 normnump[idx] = N
-                G[idx, 2] = normstat[idx]
         # Check if len(trace) is even:
         if N % 2 == 1:
             N -= 1
         # Add up every second element
         if compress == compress_values[0]:
             trace = (trace[:N:2] + trace[1:N:2]) / 2
-        else if compress == compress_values[1]:
+        elif compress == compress_values[1]:
             trace = trace[:N:2]
-        else if compress == compress_values[2]:
+        elif compress == compress_values[2]:
             trace = trace[1:N:2]
 
         N //= 2
@@ -263,6 +262,8 @@ def autocorrelate(a, m=16, deltat=1, normalize=False,
         G[:, 1] /= traceavg**2 * normstat
     else:
         G[:, 1] *= N0 / normnump
+
+    G[:, 2] = normstat
 
     return G
 

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""basic tests also available in the function docs"""
+import numpy as np
+
+from multipletau import autocorrelate, correlate
+
+
+def test_ac_compress_average():
+    ist = autocorrelate(range(42), m=2, dtype=np.float_, compress="average")
+    soll = np.array([[0.00000000e+00,   2.38210000e+04],
+                     [1.00000000e+00,   2.29600000e+04],
+                     [2.00000000e+00,   2.21000000e+04],
+                     [4.00000000e+00,   2.03775000e+04],
+                     [8.00000000e+00,   1.50612000e+04]])
+    assert np.allclose(soll, ist)
+
+def test_cc_compress_average():
+    ist = correlate(range(42), range(1, 43), m=2, dtype=np.float_,
+                    compress="average")
+    soll = np.array([[0.00000000e+00,   2.46820000e+04],
+                     [1.00000000e+00,   2.38210000e+04],
+                     [2.00000000e+00,   2.29600000e+04],
+                     [4.00000000e+00,   2.12325000e+04],
+                     [8.00000000e+00,   1.58508000e+04]])
+    assert np.allclose(soll, ist)
+
+
+def test_ac_compress_first():
+    ist = autocorrelate(range(42), m=2, dtype=np.float_,
+                        compress="first")
+    soll = np.array([[0.00000e+00, 2.38210e+04],
+                     [1.00000e+00, 2.29600e+04],
+                     [2.00000e+00, 2.21000e+04],
+                     [4.00000e+00, 1.96080e+04],
+                     [8.00000e+00, 1.31712e+04]])
+
+    assert np.allclose(soll, ist)
+
+
+def test_cc_compress_first():
+    ist = correlate(range(42), range(1, 43), m=2, dtype=np.float_,
+                        compress="first")
+    soll = np.array([[0.00000e+00, 2.46820e+04],
+                     [1.00000e+00, 2.38210e+04],
+                     [2.00000e+00, 2.29600e+04],
+                     [4.00000e+00, 2.04440e+04],
+                     [8.00000e+00, 1.39104e+04]])
+
+    assert np.allclose(soll, ist)
+
+
+def test_ac_compress_second():
+    ist = autocorrelate(range(42), m=2, dtype=np.float_,
+                        compress="second")
+    soll = np.array([[0.00000e+00, 2.38210e+04],
+                     [1.00000e+00, 2.29600e+04],
+                     [2.00000e+00, 2.21000e+04],
+                     [4.00000e+00, 2.11660e+04],
+                     [8.00000e+00, 1.71024e+04]])
+
+    assert np.allclose(soll, ist)
+
+
+def test_cc_compress_second():
+    ist = correlate(range(42), range(1, 43), m=2, dtype=np.float_,
+                        compress="second")
+    soll = np.array([[0.00000e+00, 2.46820e+04],
+                     [1.00000e+00, 2.38210e+04],
+                     [2.00000e+00, 2.29600e+04],
+                     [4.00000e+00, 2.20400e+04],
+                     [8.00000e+00, 1.79424e+04]])
+
+    assert np.allclose(soll, ist)
+
+
+if __name__ == "__main__":
+    # Run all tests
+    loc = locals()
+    for key in list(loc.keys()):
+        if key.startswith("test_") and hasattr(loc[key], "__call__"):
+            loc[key]()

--- a/tests/test_return_sum.py
+++ b/tests/test_return_sum.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""basic tests also available in the function docs"""
+import numpy as np
+
+from multipletau import autocorrelate, correlate
+
+
+def test_ac_return_sum():
+    ist, ist_count = autocorrelate(range(42), m=2, dtype=np.float_,
+                                  return_sum=True)
+    soll = np.array([[0.000000e+00, 2.382100e+04],
+                     [1.000000e+00, 2.296000e+04],
+                     [2.000000e+00, 2.210000e+04],
+                     [4.000000e+00, 1.018875e+04],
+                     [8.000000e+00, 3.586000e+03]])
+    soll_count =  [42., 41., 40., 19.,  8.]
+    assert np.allclose(soll, ist)
+    assert np.allclose(soll_count, ist_count)
+
+def test_cc_compress_average():
+    ist, ist_count = correlate(range(42), range(1, 43), m=2, dtype=np.float_,
+                               return_sum=True)
+    soll = np.array([[0.000000e+00, 2.468200e+04],
+                     [1.000000e+00, 2.382100e+04],
+                     [2.000000e+00, 2.296000e+04],
+                     [4.000000e+00, 1.061625e+04],
+                     [8.000000e+00, 3.774000e+03]])
+    soll_count =  [42., 41., 40., 19.,  8.]
+    assert np.allclose(soll, ist)
+    assert np.allclose(soll_count, ist_count)
+
+
+if __name__ == "__main__":
+    # Run all tests
+    loc = locals()
+    for key in list(loc.keys()):
+        if key.startswith("test_") and hasattr(loc[key], "__call__"):
+            loc[key]()


### PR DESCRIPTION
## Propagation of Data points
The method of propagating the values to the next register can affect the systematic error introduced by the multiple tau algorithm. Good examples are given in https://doi.org/10.1063/1.3491098 . Therefore there is a need to have a different method than averaging the data points when propagating to the next register. Using only one of the data points completely removes the systematic error at the cost of increasing the statistical error.

This is incorporated by adding the string option `compress`, where the following values are accepted:
        "average" (default): average two measurements when pushing to the next
        level of the correlator.
        "first": use only the first value when pushing to the next level of the
        correlator.
        "second": use only the second value when pushing to the next level of
        the correlator.


## Return Pure Sum
When one wants to use a different normalization, than the one toggled by the `normalize` option, the problem arises, that one needs the values stored in `normstat`. Therefore a bool option was added, so that when toggled, the not normalized sum is returned along with the values of `normstat`. This enables any further normalization by the user.
