### PR TITLE
Please make the version (and documention build) reproducible.

### DIFF
--- a/multipletau/_version.py
+++ b/multipletau/_version.py
@@ -109,6 +109,16 @@ if True:  # pragma: no cover
     except BaseException:
         pass
 
+    # 1.5. Prefer SOURCE_DATE_EPOCH if set. See <https://reproducible-builds.org/specs/source-date-epoch/>
+    try:
+        longversion = time.strftime(
+            "%Y.%m.%d-%H-%M-%S",
+            time.gmtime(float(os.environ['SOURCE_DATE_EPOCH']))
+        )
+        print("Using SOURCE_DATE_EPOCH as version: {}".format(longversion))
+    except KeyError:
+        pass
+
     # 2. previously created version file
     if longversion == "":
         # Either this is this is not a git repository or we are in the


### PR DESCRIPTION
```
Whilst working on the Reproducible Builds effort [0], we noticed
that python-multipletau could not be built reproducibly.

This is because it uses the current date which gets embedded into
the documentation file if you are building from a tarball release
and not Git.

Patch attached that uses SOURCE_DATE_EPOCH [1]. This was originally
filed in Debian as #912957 [2].

 [0] https://reproducible-builds.org/
 [1] https://reproducible-builds.org/specs/source-date-epoch/
 [2] https://bugs.debian.org/912957
```